### PR TITLE
RFC2622 allows comments staring with #, remove those

### DIFF
--- a/lib/irrc/whoisd/api.rb
+++ b/lib/irrc/whoisd/api.rb
@@ -14,7 +14,8 @@ module Irrc
           raise $1
         end
 
-        result.scan(Irrc::Irr.members_tag).flatten.map {|i| i.split /\s*,?\s+/ }.flatten
+        result.scan(Irrc::Irr.members_tag).flatten.map {|i|
+               i.gsub(/#.*/,"").split(/\s*,?\s+/)}.flatten
       end
 
       def expand_route_set_command(route_set, sources)


### PR DESCRIPTION
While generating IRR based peering filters with irrc, I faced as-set objects with comments in member: lines. irrc choked on these objects. Comment syntax in objects is OK according to RFC2622. I fixed as-set, but same problem might exist with other object types.